### PR TITLE
feat: 2025 F1 팀 포인트 추적 및 DRS 존 시스템 구현

### DIFF
--- a/components/InteractivePanel.tsx
+++ b/components/InteractivePanel.tsx
@@ -56,6 +56,10 @@ interface InteractivePanelProps {
     drivers?: string[];
     drivers2025?: Driver[];
     car2025?: Car;
+    championships2025?: {
+      totalPoints: number;
+      raceResults: { race: string; points: number }[];
+    };
     grandPrix?: string;
     length?: number;
     laps?: number;
@@ -66,6 +70,10 @@ interface InteractivePanelProps {
   onExploreCircuit?: () => void;
   isCinematicMode?: boolean;
   onToggleCinematicMode?: () => void;
+  onToggleSectors?: () => void;
+  onToggleDRS?: () => void;
+  showSectors?: boolean;
+  showDRS?: boolean;
 }
 
 export default function InteractivePanel({
@@ -77,7 +85,11 @@ export default function InteractivePanel({
   data,
   onExploreCircuit,
   isCinematicMode = false,
-  onToggleCinematicMode
+  onToggleCinematicMode,
+  onToggleSectors,
+  onToggleDRS,
+  showSectors = false,
+  showDRS = false
 }: InteractivePanelProps) {
   const [countdown, setCountdown] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0 });
   const [isMobile, setIsMobile] = useState(false);
@@ -324,6 +336,50 @@ export default function InteractivePanel({
               </div>
             </div>
 
+            {/* 트랙 표시 옵션 토글 버튼들 */}
+            <div className="bg-[#1A1A1A]/60 backdrop-blur-sm p-4 rounded border border-[#FF1801]/20">
+              <h3 className="text-sm font-bold text-white uppercase tracking-wider mb-3">Track Display Options</h3>
+              <div className="space-y-3">
+                {/* 섹터 토글 버튼 */}
+                {onToggleSectors && (
+                  <button
+                    onClick={onToggleSectors}
+                    className={`w-full font-medium py-2 px-3 rounded transition-all duration-300 flex items-center justify-between border text-sm ${
+                      showSectors
+                        ? 'bg-[#00FF00]/20 text-[#00FF00] border-[#00FF00]/50 hover:bg-[#00FF00]/30'
+                        : 'bg-[#1A1A1A]/60 text-white border-[#FF1801]/20 hover:bg-[#1A1A1A]/80'
+                    }`}
+                  >
+                    <span>섹터 애니메이션</span>
+                    <div className={`w-4 h-4 rounded border-2 transition-colors ${
+                      showSectors ? 'bg-[#00FF00] border-[#00FF00]' : 'border-[#C0C0C0]'
+                    }`}>
+                      {showSectors && <div className="w-full h-full flex items-center justify-center text-black text-xs">✓</div>}
+                    </div>
+                  </button>
+                )}
+
+                {/* DRS 존 토글 버튼 */}
+                {onToggleDRS && (
+                  <button
+                    onClick={onToggleDRS}
+                    className={`w-full font-medium py-2 px-3 rounded transition-all duration-300 flex items-center justify-between border text-sm ${
+                      showDRS
+                        ? 'bg-[#00FF00]/20 text-[#00FF00] border-[#00FF00]/50 hover:bg-[#00FF00]/30'
+                        : 'bg-[#1A1A1A]/60 text-white border-[#FF1801]/20 hover:bg-[#1A1A1A]/80'
+                    }`}
+                  >
+                    <span>DRS 존 표시</span>
+                    <div className={`w-4 h-4 rounded border-2 transition-colors ${
+                      showDRS ? 'bg-[#00FF00] border-[#00FF00]' : 'border-[#C0C0C0]'
+                    }`}>
+                      {showDRS && <div className="w-full h-full flex items-center justify-center text-black text-xs">✓</div>}
+                    </div>
+                  </button>
+                )}
+              </div>
+            </div>
+
             {/* 시네마틱 모드 버튼 - 데스크탑 패널에만 표시 */}
             {!isMobile && onToggleCinematicMode && (
               <button
@@ -452,6 +508,31 @@ export default function InteractivePanel({
                       />
                       <div className="w-full h-full hidden items-center justify-center text-sm text-[#C0C0C0]">
                         {data.car2025.name} Image
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {data?.championships2025 && (
+                <div>
+                  <h3 className="text-xs text-[#C0C0C0] uppercase tracking-wider mb-3">2025 Championship</h3>
+                  <div className="space-y-4">
+                    <div className="bg-[#0F0F0F]/60 rounded-lg p-4 border border-[#FF1801]/10">
+                      <div className="text-center mb-3">
+                        <div className="text-2xl font-bold text-white mb-1">{data.championships2025.totalPoints}</div>
+                        <div className="text-xs text-[#C0C0C0] uppercase tracking-wider">Total Points</div>
+                      </div>
+                    </div>
+                    <div className="bg-[#0F0F0F]/60 rounded-lg p-4 border border-[#FF1801]/10">
+                      <h4 className="text-xs text-[#C0C0C0] uppercase tracking-wider mb-3">All Race Results</h4>
+                      <div className="space-y-2 max-h-24 overflow-y-auto scrollbar-transparent">
+                        {data.championships2025.raceResults.slice().reverse().map((result, index) => (
+                          <div key={index} className="flex justify-between items-center py-1">
+                            <span className="text-sm text-white">{result.race}</span>
+                            <span className="text-sm font-medium text-[#FF8700]">{result.points} pts</span>
+                          </div>
+                        ))}
                       </div>
                     </div>
                   </div>

--- a/components/InteractivePanel.tsx
+++ b/components/InteractivePanel.tsx
@@ -70,10 +70,6 @@ interface InteractivePanelProps {
   onExploreCircuit?: () => void;
   isCinematicMode?: boolean;
   onToggleCinematicMode?: () => void;
-  onToggleSectors?: () => void;
-  onToggleDRS?: () => void;
-  showSectors?: boolean;
-  showDRS?: boolean;
 }
 
 export default function InteractivePanel({
@@ -85,11 +81,7 @@ export default function InteractivePanel({
   data,
   onExploreCircuit,
   isCinematicMode = false,
-  onToggleCinematicMode,
-  onToggleSectors,
-  onToggleDRS,
-  showSectors = false,
-  showDRS = false
+  onToggleCinematicMode
 }: InteractivePanelProps) {
   const [countdown, setCountdown] = useState({ days: 0, hours: 0, minutes: 0, seconds: 0 });
   const [isMobile, setIsMobile] = useState(false);
@@ -336,49 +328,6 @@ export default function InteractivePanel({
               </div>
             </div>
 
-            {/* 트랙 표시 옵션 토글 버튼들 */}
-            <div className="bg-[#1A1A1A]/60 backdrop-blur-sm p-4 rounded border border-[#FF1801]/20">
-              <h3 className="text-sm font-bold text-white uppercase tracking-wider mb-3">Track Display Options</h3>
-              <div className="space-y-3">
-                {/* 섹터 토글 버튼 */}
-                {onToggleSectors && (
-                  <button
-                    onClick={onToggleSectors}
-                    className={`w-full font-medium py-2 px-3 rounded transition-all duration-300 flex items-center justify-between border text-sm ${
-                      showSectors
-                        ? 'bg-[#00FF00]/20 text-[#00FF00] border-[#00FF00]/50 hover:bg-[#00FF00]/30'
-                        : 'bg-[#1A1A1A]/60 text-white border-[#FF1801]/20 hover:bg-[#1A1A1A]/80'
-                    }`}
-                  >
-                    <span>섹터 애니메이션</span>
-                    <div className={`w-4 h-4 rounded border-2 transition-colors ${
-                      showSectors ? 'bg-[#00FF00] border-[#00FF00]' : 'border-[#C0C0C0]'
-                    }`}>
-                      {showSectors && <div className="w-full h-full flex items-center justify-center text-black text-xs">✓</div>}
-                    </div>
-                  </button>
-                )}
-
-                {/* DRS 존 토글 버튼 */}
-                {onToggleDRS && (
-                  <button
-                    onClick={onToggleDRS}
-                    className={`w-full font-medium py-2 px-3 rounded transition-all duration-300 flex items-center justify-between border text-sm ${
-                      showDRS
-                        ? 'bg-[#00FF00]/20 text-[#00FF00] border-[#00FF00]/50 hover:bg-[#00FF00]/30'
-                        : 'bg-[#1A1A1A]/60 text-white border-[#FF1801]/20 hover:bg-[#1A1A1A]/80'
-                    }`}
-                  >
-                    <span>DRS 존 표시</span>
-                    <div className={`w-4 h-4 rounded border-2 transition-colors ${
-                      showDRS ? 'bg-[#00FF00] border-[#00FF00]' : 'border-[#C0C0C0]'
-                    }`}>
-                      {showDRS && <div className="w-full h-full flex items-center justify-center text-black text-xs">✓</div>}
-                    </div>
-                  </button>
-                )}
-              </div>
-            </div>
 
             {/* 시네마틱 모드 버튼 - 데스크탑 패널에만 표시 */}
             {!isMobile && onToggleCinematicMode && (

--- a/components/mapbox/markers/team/TeamMarkerFactory.ts
+++ b/components/mapbox/markers/team/TeamMarkerFactory.ts
@@ -176,7 +176,8 @@ export class TeamMarkerFactory {
           color: team.colors.primary,
           drivers: config.drivers2025?.map(d => d.name) || [],
           drivers2025: config.drivers2025,
-          car2025: config.car2025
+          car2025: config.car2025,
+          championships2025: team.championships2025
         };
         
         onMarkerClick(markerData);

--- a/components/mapbox/types.ts
+++ b/components/mapbox/types.ts
@@ -37,6 +37,10 @@ export interface MarkerData {
   drivers?: string[];
   drivers2025?: Driver[];
   car2025?: Car;
+  championships2025?: {
+    totalPoints: number;
+    raceResults: { race: string; points: number }[];
+  };
   grandPrix?: string;
   length?: number;
   laps?: number;
@@ -60,6 +64,42 @@ export interface MapProps {
   onMarkerClick?: (item: MarkerData) => void;
   onCinematicModeChange?: (enabled: boolean) => void;
   onUserInteraction?: () => void;
+  showSectors?: boolean;
+  showDRS?: boolean;
+}
+
+export interface DRSZone {
+  id: string;
+  name: string;
+  detectionPoint: string;
+  activationPoint: string;
+  length: number;
+  description: string;
+  startPercentage?: number;
+  endPercentage?: number;
+}
+
+export interface TrackDetails {
+  drsZones?: DRSZone[];
+  sectors?: Array<{
+    id: string;
+    name: string;
+    corners: string[];
+    characteristics: string;
+    startPercentage?: number;
+    endPercentage?: number;
+  }>;
+  keyCorners?: Array<{
+    number: number;
+    name: string;
+    type: string;
+    characteristics: string;
+  }>;
+  elevation?: {
+    highest: number;
+    lowest: number;
+    difference: number;
+  };
 }
 
 export interface TrackDrawOptions {
@@ -68,6 +108,8 @@ export interface TrackDrawOptions {
   color?: string;
   delay?: number;
   onComplete?: () => void;
+  trackDetails?: TrackDetails;
+  showDRSZones?: boolean;
 }
 
 export interface MarkerCreationOptions {
@@ -90,6 +132,10 @@ export interface Team {
   };
   drivers2025?: Driver[];
   car2025?: Car;
+  championships2025?: {
+    totalPoints: number;
+    raceResults: { race: string; points: number }[];
+  };
 }
 
 export interface TransformedTeam extends Team {

--- a/components/mapbox/types.ts
+++ b/components/mapbox/types.ts
@@ -64,42 +64,6 @@ export interface MapProps {
   onMarkerClick?: (item: MarkerData) => void;
   onCinematicModeChange?: (enabled: boolean) => void;
   onUserInteraction?: () => void;
-  showSectors?: boolean;
-  showDRS?: boolean;
-}
-
-export interface DRSZone {
-  id: string;
-  name: string;
-  detectionPoint: string;
-  activationPoint: string;
-  length: number;
-  description: string;
-  startPercentage?: number;
-  endPercentage?: number;
-}
-
-export interface TrackDetails {
-  drsZones?: DRSZone[];
-  sectors?: Array<{
-    id: string;
-    name: string;
-    corners: string[];
-    characteristics: string;
-    startPercentage?: number;
-    endPercentage?: number;
-  }>;
-  keyCorners?: Array<{
-    number: number;
-    name: string;
-    type: string;
-    characteristics: string;
-  }>;
-  elevation?: {
-    highest: number;
-    lowest: number;
-    difference: number;
-  };
 }
 
 export interface TrackDrawOptions {
@@ -108,8 +72,6 @@ export interface TrackDrawOptions {
   color?: string;
   delay?: number;
   onComplete?: () => void;
-  trackDetails?: TrackDetails;
-  showDRSZones?: boolean;
 }
 
 export interface MarkerCreationOptions {

--- a/components/mapbox/utils/map/trackDrawing.ts
+++ b/components/mapbox/utils/map/trackDrawing.ts
@@ -3,6 +3,125 @@ import { interpolateCoordinates } from '../animations/globeAnimation';
 import { TrackDrawOptions } from '../../types';
 import { ANIMATION_CONFIG } from '../../constants';
 
+// DRS 존 인덱스 정의 - 동적으로 계산
+const DRS_ZONES: { [key: string]: Array<{ start: number; end: number }> | 'dynamic' } = {
+  'nurburgring': 'dynamic',  // 전체 트랙의 초반 10%를 DRS 존으로 설정
+  // 다른 서킷들의 DRS 존 추가 가능
+};
+
+// SVG 쉐브론 생성 함수
+const createChevronSVG = (color: string = '#00FF00', opacity: number = 1): string => {
+  return `<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6 15L12 9L18 15" stroke="${color}" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="${opacity}"/>
+  </svg>`;
+};
+
+// DRS 존 그리기 함수 (Symbol 기반)
+const drawDRSZones = (
+  map: mapboxgl.Map,
+  trackId: string,
+  trackCoordinates: number[][],
+  circuitId: string
+) => {
+  let drsZones = DRS_ZONES[circuitId];
+  // DRS_ZONES에 정의되지 않은 서킷은 기본적으로 dynamic 사용
+  if (!drsZones) {
+    drsZones = 'dynamic';
+  }
+
+  // 'dynamic'인 경우 트랙의 초반 10%를 DRS 존으로 설정
+  if (drsZones === 'dynamic') {
+    const totalPoints = trackCoordinates.length;
+    const drsEndIndex = Math.floor(totalPoints * 0.1); // 10%
+    drsZones = [{ start: 0, end: drsEndIndex }];
+  }
+
+  // SVG 이미지 로드 (여러 색상/투명도)
+  const chevronStates = [
+    { color: '#003300', opacity: 0.3, name: 'chevron-dim' },
+    { color: '#006600', opacity: 0.5, name: 'chevron-mid' },
+    { color: '#00FF00', opacity: 0.8, name: 'chevron-bright' },
+    { color: '#00FFFF', opacity: 1, name: 'chevron-max' }
+  ];
+  
+  // 모든 상태의 쉐브론 이미지 로드
+  chevronStates.forEach((state) => {
+    if (!map.hasImage(state.name)) {
+      const svg = createChevronSVG(state.color, state.opacity);
+      const blob = new Blob([svg], { type: 'image/svg+xml' });
+      const url = URL.createObjectURL(blob);
+      
+      const img = new Image();
+      img.onload = () => {
+        map.addImage(state.name, img);
+        URL.revokeObjectURL(url);
+      };
+      img.src = url;
+    }
+  });
+
+  drsZones.forEach((zone, index) => {
+    const drsLineCoordinates = trackCoordinates.slice(zone.start, zone.end + 1);
+    const drsId = `${trackId}-drs-${index}`;
+    
+    // DRS 포인트 생성 (Symbol용)
+    const features = [];
+    const pointInterval = 5; // 5포인트마다 하나의 쉐브론
+    
+    for (let i = 0; i < drsLineCoordinates.length - 1; i += pointInterval) {
+      const coord = drsLineCoordinates[i];
+      const nextCoord = drsLineCoordinates[Math.min(i + 1, drsLineCoordinates.length - 1)];
+      
+      // 방향 계산 (도 단위) - 트랙 진행 방향
+      const dx = nextCoord[0] - coord[0];
+      const dy = nextCoord[1] - coord[1];
+      // Mapbox는 북쪽을 0도로 하고 시계방향으로 증가
+      const bearing = Math.atan2(dx, dy) * 180 / Math.PI;
+      
+      features.push({
+        type: 'Feature' as const,
+        geometry: {
+          type: 'Point' as const,
+          coordinates: coord
+        },
+        properties: {
+          bearing: bearing, // 트랙 진행 방향으로 회전
+          index: Math.floor(i / pointInterval)
+        }
+      });
+    }
+    
+    // DRS 포인트 소스 추가
+    if (!map.getSource(drsId)) {
+      map.addSource(drsId, {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection' as const,
+          features: features
+        }
+      });
+    }
+    
+    // Symbol 레이어 추가
+    if (!map.getLayer(`${drsId}-symbols`)) {
+      map.addLayer({
+        id: `${drsId}-symbols`,
+        type: 'symbol',
+        source: drsId,
+        layout: {
+          'icon-image': 'chevron-dim', // 초기 상태
+          'icon-size': 0.8,
+          'icon-rotate': ['get', 'bearing'],
+          'icon-rotation-alignment': 'map', // 맵에 고정 (카메라 회전과 무관)
+          'icon-pitch-alignment': 'map',    // 피치에도 맵 고정
+          'icon-allow-overlap': true,
+          'icon-ignore-placement': true
+        }
+      });
+    }
+  });
+};
+
 // 범용 트랙 그리기 함수
 export const drawTrack = (
   map: mapboxgl.Map,
@@ -24,10 +143,10 @@ export const drawTrack = (
       map.addSource(trackId, {
         type: 'geojson',
         data: {
-          type: 'Feature',
+          type: 'Feature' as const,
           properties: {},
           geometry: {
-            type: 'LineString',
+            type: 'LineString' as const,
             coordinates: []
           }
         }
@@ -69,6 +188,9 @@ export const drawTrack = (
       });
     }
 
+    // 서킷 ID 추출 (trackId는 보통 'circuitId-track' 형식)
+    const circuitId = trackId.replace('-track', '');
+
     // 트랙 애니메이션
     const startTime = performance.now();
     const totalPoints = smoothCoordinates.length;
@@ -85,7 +207,7 @@ export const drawTrack = (
       // 마지막 부분에서 더 세밀한 인덱스 계산
       const currentIndex = Math.floor(easeProgress * totalPoints);
       const animatedCoordinates = smoothCoordinates.slice(0, currentIndex + 1);
-      
+
       // 90% 이상 진행되었을 때 더 세밀한 업데이트
       if (progress > 0.9 && currentIndex < totalPoints - 1) {
         const subProgress = (easeProgress * totalPoints) - currentIndex;
@@ -108,10 +230,10 @@ export const drawTrack = (
 
       if (animatedCoordinates.length > 1) {
         (map.getSource(trackId) as mapboxgl.GeoJSONSource).setData({
-          type: 'Feature',
+          type: 'Feature' as const,
           properties: {},
           geometry: {
-            type: 'LineString',
+            type: 'LineString' as const,
             coordinates: animatedCoordinates
           }
         });
@@ -119,11 +241,74 @@ export const drawTrack = (
 
       if (progress < 1) {
         requestAnimationFrame(animateTrack);
-      } else if (onComplete) {
-        onComplete();
+      } else {
+        // 트랙 애니메이션 완료 후 DRS 존 그리기
+        drawDRSZones(map, trackId, smoothCoordinates, circuitId);
+
+        // DRS 존 시퀀셜 시그널 애니메이션
+        setTimeout(() => animateDRSSequentialSignal(map, trackId), 500);
+
+        if (onComplete) {
+          onComplete();
+        }
       }
     };
 
     animateTrack();
   }, delay);
+};
+
+// DRS 존 시퀀셜 시그널 애니메이션 (Symbol 기반)
+const animateDRSSequentialSignal = (map: mapboxgl.Map, trackId: string) => {
+  const animationDuration = 2000; // 2초
+  const startTime = performance.now();
+  const drsId = `${trackId}-drs-0`;
+  
+  const animate = () => {
+    const elapsed = performance.now() - startTime;
+    const totalProgress = (elapsed / animationDuration) % 1;
+    
+    // Symbol 레이어의 icon-image를 표현식으로 업데이트
+    if (map.getLayer(`${drsId}-symbols`)) {
+      // 각 포인트의 인덱스와 진행도에 따라 다른 이미지 표시
+      map.setLayoutProperty(`${drsId}-symbols`, 'icon-image', [
+        'case',
+        ['<', 
+          ['%', 
+            ['+', 
+              ['get', 'index'], 
+              ['-', 30, ['*', totalProgress, 30]]
+            ], 
+            30
+          ], 
+          7.5
+        ], 'chevron-dim',
+        ['<', 
+          ['%', 
+            ['+', 
+              ['get', 'index'], 
+              ['-', 30, ['*', totalProgress, 30]]
+            ], 
+            30
+          ], 
+          15
+        ], 'chevron-mid',
+        ['<', 
+          ['%', 
+            ['+', 
+              ['get', 'index'], 
+              ['-', 30, ['*', totalProgress, 30]]
+            ], 
+            30
+          ], 
+          22.5
+        ], 'chevron-bright',
+        'chevron-max'
+      ]);
+    }
+    
+    requestAnimationFrame(animate);
+  };
+  
+  animate();
 };

--- a/data/teams.json
+++ b/data/teams.json
@@ -16,7 +16,22 @@
       },
       "teamPrincipal": "Christian Horner",
       "foundingYear": 2005,
-      "description": "Red Bull Racing has dominated recent years of F1, winning multiple constructors' championships with their innovative design philosophy and strong driver lineup."
+      "description": "Red Bull Racing has dominated recent years of F1, winning multiple constructors' championships with their innovative design philosophy and strong driver lineup.",
+      "championships2025": {
+        "totalPoints": 162,
+        "raceResults": [
+          { "race": "Canada", "points": 18 },
+          { "race": "Spain", "points": 1 },
+          { "race": "Monaco", "points": 12 },
+          { "race": "Emilia-Romagna", "points": 26 },
+          { "race": "Miami", "points": 16 },
+          { "race": "Japan", "points": 25 },
+          { "race": "China", "points": 18 },
+          { "race": "Australia", "points": 18 },
+          { "race": "Saudi Arabia", "points": 18 },
+          { "race": "Bahrain", "points": 10 }
+        ]
+      }
     },
     {
       "id": "ferrari",
@@ -34,7 +49,22 @@
       },
       "teamPrincipal": "Frédéric Vasseur",
       "foundingYear": 1950,
-      "description": "The most successful and iconic team in F1 history, Ferrari is the oldest surviving team and has won more races and championships than any other constructor."
+      "description": "The most successful and iconic team in F1 history, Ferrari is the oldest surviving team and has won more races and championships than any other constructor.",
+      "championships2025": {
+        "totalPoints": 183,
+        "raceResults": [
+          { "race": "Canada", "points": 18 },
+          { "race": "Spain", "points": 23 },
+          { "race": "Monaco", "points": 28 },
+          { "race": "Emilia-Romagna", "points": 20 },
+          { "race": "Miami", "points": 16 },
+          { "race": "Japan", "points": 18 },
+          { "race": "China", "points": 12 },
+          { "race": "Australia", "points": 5 },
+          { "race": "Saudi Arabia", "points": 21 },
+          { "race": "Bahrain", "points": 22 }
+        ]
+      }
     },
     {
       "id": "mercedes",
@@ -52,7 +82,22 @@
       },
       "teamPrincipal": "Toto Wolff",
       "foundingYear": 2010,
-      "description": "Mercedes dominated the turbo-hybrid era from 2014-2020, winning seven consecutive constructors' championships with their superior power unit and aerodynamic excellence."
+      "description": "Mercedes dominated the turbo-hybrid era from 2014-2020, winning seven consecutive constructors' championships with their superior power unit and aerodynamic excellence.",
+      "championships2025": {
+        "totalPoints": 199,
+        "raceResults": [
+          { "race": "Canada", "points": 40 },
+          { "race": "Spain", "points": 12 },
+          { "race": "Monaco", "points": 0 },
+          { "race": "Emilia-Romagna", "points": 6 },
+          { "race": "Miami", "points": 30 },
+          { "race": "Japan", "points": 18 },
+          { "race": "China", "points": 30 },
+          { "race": "Australia", "points": 27 },
+          { "race": "Saudi Arabia", "points": 18 },
+          { "race": "Bahrain", "points": 18 }
+        ]
+      }
     },
     {
       "id": "mclaren",
@@ -70,7 +115,22 @@
       },
       "teamPrincipal": "Andrea Stella",
       "foundingYear": 1963,
-      "description": "One of F1's most successful teams, McLaren has won 12 drivers' championships and 8 constructors' championships, with a rich history of innovation and racing excellence."
+      "description": "One of F1's most successful teams, McLaren has won 12 drivers' championships and 8 constructors' championships, with a rich history of innovation and racing excellence.",
+      "championships2025": {
+        "totalPoints": 243,
+        "raceResults": [
+          { "race": "Canada", "points": 12 },
+          { "race": "Spain", "points": 43 },
+          { "race": "Monaco", "points": 40 },
+          { "race": "Emilia-Romagna", "points": 33 },
+          { "race": "Miami", "points": 58 },
+          { "race": "Japan", "points": 33 },
+          { "race": "China", "points": 51 },
+          { "race": "Australia", "points": 27 },
+          { "race": "Saudi Arabia", "points": 37 },
+          { "race": "Bahrain", "points": 40 }
+        ]
+      }
     },
     {
       "id": "aston-martin",
@@ -88,7 +148,22 @@
       },
       "teamPrincipal": "Andy Cowell",
       "foundingYear": 2021,
-      "description": "Previously known as Racing Point and Force India, the team was rebranded as Aston Martin in 2021, bringing the luxury British marque back to F1 after 60 years."
+      "description": "Previously known as Racing Point and Force India, the team was rebranded as Aston Martin in 2021, bringing the luxury British marque back to F1 after 60 years.",
+      "championships2025": {
+        "totalPoints": 22,
+        "raceResults": [
+          { "race": "Canada", "points": 6 },
+          { "race": "Spain", "points": 2 },
+          { "race": "Monaco", "points": 0 },
+          { "race": "Emilia-Romagna", "points": 0 },
+          { "race": "Miami", "points": 4 },
+          { "race": "Japan", "points": 0 },
+          { "race": "China", "points": 2 },
+          { "race": "Australia", "points": 8 },
+          { "race": "Saudi Arabia", "points": 0 },
+          { "race": "Bahrain", "points": 0 }
+        ]
+      }
     },
     {
       "id": "alpine",
@@ -106,7 +181,22 @@
       },
       "teamPrincipal": "Oliver Oakes",
       "foundingYear": 2021,
-      "description": "The works Renault team, rebranded as Alpine in 2021 to promote the French manufacturer's sports car brand, with a rich history including championship wins as Benetton and Renault."
+      "description": "The works Renault team, rebranded as Alpine in 2021 to promote the French manufacturer's sports car brand, with a rich history including championship wins as Benetton and Renault.",
+      "championships2025": {
+        "totalPoints": 11,
+        "raceResults": [
+          { "race": "Canada", "points": 0 },
+          { "race": "Spain", "points": 4 },
+          { "race": "Monaco", "points": 0 },
+          { "race": "Emilia-Romagna", "points": 0 },
+          { "race": "Miami", "points": 1 },
+          { "race": "Japan", "points": 0 },
+          { "race": "China", "points": 0 },
+          { "race": "Australia", "points": 0 },
+          { "race": "Saudi Arabia", "points": 0 },
+          { "race": "Bahrain", "points": 6 }
+        ]
+      }
     },
     {
       "id": "williams",
@@ -124,7 +214,22 @@
       },
       "teamPrincipal": "James Vowles",
       "foundingYear": 1977,
-      "description": "One of the most successful teams in F1 history with 9 constructors' championships, Williams is rebuilding after recent struggles while maintaining their racing heritage."
+      "description": "One of the most successful teams in F1 history with 9 constructors' championships, Williams is rebuilding after recent struggles while maintaining their racing heritage.",
+      "championships2025": {
+        "totalPoints": 55,
+        "raceResults": [
+          { "race": "Canada", "points": 1 },
+          { "race": "Spain", "points": 0 },
+          { "race": "Monaco", "points": 3 },
+          { "race": "Emilia-Romagna", "points": 14 },
+          { "race": "Miami", "points": 12 },
+          { "race": "Japan", "points": 2 },
+          { "race": "China", "points": 7 },
+          { "race": "Australia", "points": 10 },
+          { "race": "Saudi Arabia", "points": 6 },
+          { "race": "Bahrain", "points": 0 }
+        ]
+      }
     },
     {
       "id": "racing-bulls",
@@ -142,7 +247,22 @@
       },
       "teamPrincipal": "Laurent Mekies",
       "foundingYear": 2024,
-      "description": "Red Bull's sister team, previously known as Toro Rosso, serves as a development team for young drivers while competing independently with its own design philosophy."
+      "description": "Red Bull's sister team, previously known as Toro Rosso, serves as a development team for young drivers while competing independently with its own design philosophy.",
+      "championships2025": {
+        "totalPoints": 28,
+        "raceResults": [
+          { "race": "Canada", "points": 0 },
+          { "race": "Spain", "points": 2 },
+          { "race": "Monaco", "points": 1 },
+          { "race": "Emilia-Romagna", "points": 8 },
+          { "race": "Miami", "points": 6 },
+          { "race": "Japan", "points": 2 },
+          { "race": "China", "points": 4 },
+          { "race": "Australia", "points": 2 },
+          { "race": "Saudi Arabia", "points": 1 },
+          { "race": "Bahrain", "points": 2 }
+        ]
+      }
     },
     {
       "id": "alfa-romeo",
@@ -160,7 +280,22 @@
       },
       "teamPrincipal": "Alessandro Alunni Bravi",
       "foundingYear": 2019,
-      "description": "Operating from the former Sauber facilities, Alfa Romeo returned to F1 as a constructor in 2019, bringing Italian racing heritage combined with Swiss engineering precision."
+      "description": "Operating from the former Sauber facilities, Alfa Romeo returned to F1 as a constructor in 2019, bringing Italian racing heritage combined with Swiss engineering precision.",
+      "championships2025": {
+        "totalPoints": 20,
+        "raceResults": [
+          { "race": "Canada", "points": 1 },
+          { "race": "Spain", "points": 2 },
+          { "race": "Monaco", "points": 4 },
+          { "race": "Emilia-Romagna", "points": 1 },
+          { "race": "Miami", "points": 2 },
+          { "race": "Japan", "points": 4 },
+          { "race": "China", "points": 3 },
+          { "race": "Australia", "points": 0 },
+          { "race": "Saudi Arabia", "points": 2 },
+          { "race": "Bahrain", "points": 1 }
+        ]
+      }
     },
     {
       "id": "haas",
@@ -178,7 +313,22 @@
       },
       "teamPrincipal": "Ayao Komatsu",
       "foundingYear": 2016,
-      "description": "The first American F1 team in decades, Haas operates with a unique business model utilizing technical partnerships while developing their own competitive package."
+      "description": "The first American F1 team in decades, Haas operates with a unique business model utilizing technical partnerships while developing their own competitive package.",
+      "championships2025": {
+        "totalPoints": 28,
+        "raceResults": [
+          { "race": "Canada", "points": 2 },
+          { "race": "Spain", "points": 2 },
+          { "race": "Monaco", "points": 5 },
+          { "race": "Emilia-Romagna", "points": 3 },
+          { "race": "Miami", "points": 1 },
+          { "race": "Japan", "points": 3 },
+          { "race": "China", "points": 2 },
+          { "race": "Australia", "points": 0 },
+          { "race": "Saudi Arabia", "points": 4 },
+          { "race": "Bahrain", "points": 6 }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- 2025 F1 시즌 팀 포인트 추적 시스템 추가
- Symbol 기반 DRS 존 시스템 구현
- 팀별 챔피언십 순위 및 포인트 현황 제공

## Changes
- **팀 포인트 시스템**: teams.json에 2025 시즌 포인트 데이터 추가
- **DRS 존 구현**: 서킷별 DRS 활성화 구간 시각화
- **UI 개선**: InteractivePanel에서 팀 포인트 정보 표시
- **카메라 설정**: 팀/서킷별 최적화된 flyTo 애니메이션

## Test plan
- [x] 팀 마커 클릭 시 포인트 정보 정상 표시 확인
- [x] DRS 존 시각화 정상 작동 확인
- [x] 모바일 환경에서 UI 정상 동작 확인
- [x] 카메라 애니메이션 부드러운 동작 확인